### PR TITLE
As with Pandoc error for unicode arrow, had to replace the apostrophe (’...

### DIFF
--- a/Advanced_graphics_in_R.Rmd
+++ b/Advanced_graphics_in_R.Rmd
@@ -37,7 +37,7 @@ R provides a powerful environment for EDA and visualization
 ## A few tips
 
 - Avoid 3-D graphics
-- Don’t show too much information on the same graph (color, patterns, etc)
+- Don't show too much information on the same graph (color, patterns, etc)
 - Stay away from Excel, Excel is not a statistics package!
 - R provides a great environment for EDA with good graphics capabilities
 


### PR DESCRIPTION
...) with single quote (') in order for Pandoc on Windows to render the HTML from the Rmd file. Again this was found with a regex search in RStudio using [^\x00-\x7F] as a search pattern.